### PR TITLE
fake latency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,5 @@ _ReSharper*/
 
 # JetBrains Rider
 *.sln.iml
+/haven-tf2/x64
+/vcpkg_installed/x64-windows

--- a/haven-tf2/c_client_state.h
+++ b/haven-tf2/c_client_state.h
@@ -3,7 +3,8 @@
 class c_client_state
 {
 public:
-    char pad0[16];
+    void* vtables[3];
+    int socket;
     i_net_channel_info* network_channel;
     char pad1[320];
     struct c_clock_drift

--- a/haven-tf2/client.h
+++ b/haven-tf2/client.h
@@ -11,6 +11,7 @@ public:
     bool m_unloading = false, m_debug_build = true;
     HWND m_hwnd = nullptr;
     view_matrix m_view_matrix;
+    int last_reliable_state;
 
     void init();
     void unload();

--- a/haven-tf2/haven-tf2.vcxproj
+++ b/haven-tf2/haven-tf2.vcxproj
@@ -128,6 +128,7 @@
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <ForcedIncludeFiles>pch.h;%(ForcedIncludeFiles)</ForcedIncludeFiles>
       <OmitFramePointers>false</OmitFramePointers>
+      <BuildStlModules>false</BuildStlModules>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/haven-tf2/hooks.h
+++ b/haven-tf2/hooks.h
@@ -37,6 +37,10 @@ public:
 
         using get_outer_abs_velo_fn = void(__stdcall*)(vector);
         get_outer_abs_velo_fn get_outer_abs_velocity_orig;
+
+        using send_datagram_fn = int(__fastcall*)(i_net_channel_info*, bf_write*);
+        send_datagram_fn send_datagram;
+
         WNDPROC wnd_proc;
     } m_original;
 

--- a/haven-tf2/interfaces.cpp
+++ b/haven-tf2/interfaces.cpp
@@ -28,7 +28,7 @@ void c_interfaces::gather()
         this->m_engine_trace = engine.get_interface("EngineTraceClient003", true).as<i_engine_trace>();
         this->m_model_info = engine.get_interface("VModelInfoClient006", true).as<i_model_info>();
         this->m_render_view = engine.get_interface("VEngineRenderView014", true).as<c_render_view>();
-        this->m_client_state = *reinterpret_cast<c_client_state**>(engine.get_sig("48 8D 0D ? ? ? ? E8 ? ? ? ? F3 0F 5E 05").rel32(0x3));
+        this->m_client_state = reinterpret_cast<c_client_state*>(engine.get_sig("48 8D 0D ? ? ? ? E8 ? ? ? ? F3 0F 5E 05").rel32(0x3));
     }
 
     const auto steam = g_modules.get("steamclient64.dll");

--- a/haven-tf2/ui.cpp
+++ b/haven-tf2/ui.cpp
@@ -101,6 +101,8 @@ void c_ui::init()
                 this->m_controls.misc.third_person_horizontal_offset = misc2->add_slider("Thirdperson Horizontal Offset", -100, 100);
                 this->m_controls.misc.third_person_vertical_offset = misc2->add_slider("Thirdperson Vertical Offset", -100, 100);
                 this->m_controls.misc.third_person_distance_offset = misc2->add_slider("Thirdperson Distance Offset", -100, 100);
+                this->m_controls.misc.fake_latency_toggle = misc2->add_checkbox("Fake Latency");
+                this->m_controls.misc.fake_latency_amount = misc2->add_slider("Latency Amount", 0, 900);
             }
         }
     }

--- a/haven-tf2/ui.h
+++ b/haven-tf2/ui.h
@@ -117,6 +117,8 @@ public:
             std::shared_ptr<c_slider> third_person_horizontal_offset;
             std::shared_ptr<c_slider> third_person_vertical_offset;
             std::shared_ptr<c_slider> third_person_distance_offset;
+            std::shared_ptr<c_checkbox> fake_latency_toggle;
+            std::shared_ptr<c_slider> fake_latency_amount;
         } misc;
     } m_controls;
 


### PR DESCRIPTION
does the "proper" way (that every csgo/tf2 p2c does) for doing fake latency
works flawlessly without any extra fixes or stuff

only thing that needs to be changed is for regular aimbot to compensate for the extended latency, as the lag record window moves away from the player you can see once you go past 200ms.

changes to gitignore + vcxproj was just for me, you can revert them if it causes problems

:D